### PR TITLE
Add missing facade

### DIFF
--- a/src/FattureInCloudFacade.php
+++ b/src/FattureInCloudFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OfflineAgency\FattureInCloud;
+
+class FattureInCloudFacade extends \Illuminate\Support\Facades\Facade
+{
+    public static function getFacadeAccessor()
+    {
+        return 'fatture-in-cloud';
+    }
+}

--- a/tests/Unit/FattureInCloudFacadeTest.php
+++ b/tests/Unit/FattureInCloudFacadeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Unit;
+
+use Mockery;
+use OfflineAgency\FattureInCloud\FattureInCloud;
+use OfflineAgency\FattureInCloud\FattureInCloudFacade;
+use OfflineAgency\FattureInCloud\FattureInCloudServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class FattureInCloudFacadeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_loads_facade_alias()
+    {
+        $this->app->singleton(
+            'fatture-in-cloud',
+            function ($app) {
+                return Mockery::mock(FattureInCloud::class, function ($mock) {
+                    $mock->shouldReceive('test');
+                });
+            });
+
+        \FattureInCloud::test();
+    }
+
+    public function getPackageProviders()
+    {
+        return [
+            FattureInCloudServiceProvider::class,
+        ];
+    }
+
+    public function getPackageAliases()
+    {
+        return [
+            'FattureInCloud' => FattureInCloudFacade::class,
+        ];
+    }
+}


### PR DESCRIPTION
The facade was defined in the `composer.json` file but was not implemented.

This PR implements the facade and tests the correct alias resolution.